### PR TITLE
Set default initial wags value to 3

### DIFF
--- a/db/migrate/20160514002945_change_wags_default_value.rb
+++ b/db/migrate/20160514002945_change_wags_default_value.rb
@@ -1,0 +1,5 @@
+class ChangeWagsDefaultValue < ActiveRecord::Migration
+  def change
+    change_column :users, :wags, :integer, :default => 3
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160507182553) do
+ActiveRecord::Schema.define(version: 20160514002945) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -99,7 +99,7 @@ ActiveRecord::Schema.define(version: 20160507182553) do
     t.integer  "zipcode"
     t.boolean  "logged_in",              default: true
     t.boolean  "admin",                  default: false
-    t.integer  "wags",                   default: 0
+    t.integer  "wags",                   default: 3
     t.datetime "created_at",                             null: false
     t.datetime "updated_at",                             null: false
     t.string   "encrypted_password",     default: "",    null: false


### PR DESCRIPTION
Andrii - please review. We want to set the initial wags value to 3 as a bonus for user sign up. I can't verify working 100% because the auth changes made are preventing me from creating user account with existing app after I dropped my db. Please confirm that auth is functioning in new app or in the works. Thanks.  
